### PR TITLE
Add .wercker to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle
 vendor
 corpus/*
+.wercker


### PR DESCRIPTION
I'm pretty much just looking at how build status is displayed for Wercker.
